### PR TITLE
Use tree-kill to kill processes

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "pascal-case": "3.1.2",
     "prettier": "2.2.1",
     "semver": "7.3.4",
+    "tree-kill": "^1.2.2",
     "typescript": "4.2.3",
     "vscode-languageclient": "7.0.0",
     "vscode-languageserver-protocol": "3.16.0"

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "pascal-case": "3.1.2",
     "prettier": "2.2.1",
     "semver": "7.3.4",
-    "tree-kill": "^1.2.2",
+    "tree-kill": "1.2.2",
     "typescript": "4.2.3",
     "vscode-languageclient": "7.0.0",
     "vscode-languageserver-protocol": "3.16.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import * as path from "path";
 import * as fs from "fs";
 import { pascalCase } from "pascal-case";
 import * as cp from "child_process";
+import kill from "tree-kill";
 
 import {
   workspace,
@@ -115,13 +116,9 @@ const killCompiler = () => {
   let killedProcess = false;
 
   childProcesses = childProcesses.filter((childProcess) => {
-    const res = childProcess.kill("SIGINT");
-
-    if (res) {
-      killedProcess = true;
-    }
-
-    return !res;
+    kill(childProcess.pid);
+    killedProcess = true;
+    return false;
   });
 
   return killedProcess;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4189,6 +4189,11 @@ tr46@^2.0.2:
   dependencies:
     punycode "^2.1.1"
 
+tree-kill@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
+  integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
+
 ts-jest@26.5.3:
   version "26.5.3"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.3.tgz#a6ee00ba547be3b09877550df40a1465d0295554"


### PR DESCRIPTION
It seems that the node api itself is not a reliable way to kill child processes. But `tree-kill` looks like it is.